### PR TITLE
change: accordion components to remove hooks and use vanilla js toggle (wp blocks limitation)

### DIFF
--- a/.storybook/index.css
+++ b/.storybook/index.css
@@ -2224,6 +2224,10 @@ select {
   display: grid;
 }
 
+.\!hidden {
+  display: none !important;
+}
+
 .hidden {
   display: none;
 }

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -16,6 +16,12 @@ Prefix the change with one of these keywords:
 
 ## [Unreleased]
 
+## [0.4.7]
+
+### Changes
+
+- Description accordion to remove hooks instead add vanilla script to handle toggle
+
 ## [0.4.6]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -40,9 +40,11 @@
   "dependencies": {
     "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.18",
+    "@types/react-helmet": "^6.1.9",
     "rds-tailwind-theme": "0.5.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-helmet": "^6.1.0",
     "react-intersection-observer": "9.5.2"
   },
   "peerDependencies": {

--- a/src/components/Description/DescriptionAccordion.tsx
+++ b/src/components/Description/DescriptionAccordion.tsx
@@ -1,39 +1,34 @@
-import { useState } from 'react'
 import { styles } from './Description.Styles'
 import { ChevronRightIcon } from '@heroicons/react/24/outline'
 import { proseStyles } from '../../utils/globalClasses'
-
+import {Helmet} from "react-helmet";
 export interface DescriptionAccordionProps {
   term: string
   children: React.ReactNode
 }
 
 export const DescriptionAccordion = ({ term, children }: DescriptionAccordionProps) => {
-  const [ariaExpanded, setAriaExpanded] = useState(false)
-  const [collapsed, setCollapsed] = useState(true)
-  const [hidden, setHidden] = useState(true)
 
-  const onContentToggle = () => {
-    setAriaExpanded((current) => !current)
-    setCollapsed((current) => !current)
-    setHidden((current) => !current)
-  }
-
-  const termLabel = term.toLowerCase().replace(/ +/g, '-')
+  const termLabel = term && typeof term === 'string' ? 'accordion-' + term.toLowerCase().replace(/ +/g, '-') : '';
 
   return (
-    <div className={`${styles.base} ${styles.accordion}`}>
-      <dt className={`${styles.term} ${proseStyles.base}`}>
-        <button className={styles.button} id={termLabel} aria-expanded={ariaExpanded} onClick={onContentToggle}>
-          {term}
-          <ChevronRightIcon className={`${styles.chevron} ${collapsed ? 'rotate-0' : 'rotate-90'}`} />
-        </button>
-      </dt>
+    <>
+      <Helmet>
+        <script src="./src/components/Description/script.js" type="text/javascript" />
+      </Helmet>
+      <div className={`accordion ${styles.base} ${styles.accordion}`}>
+        <dt className={`${styles.term} ${proseStyles.base}`}>
+          <button className={`accordion__button ${styles.button}`} aria-expanded='false' aria-controls={termLabel}>
+            {term}
+            <ChevronRightIcon className={`accordion__icon ${styles.chevron} rotate-0}`} />
+          </button>
+        </dt>
 
-      <dd className={`${proseStyles.base} ${styles.accordionDef}`} hidden={hidden}>
-        {children}
-      </dd>
-    </div>
+        <dd className={`accordion__content ${styles.accordionDef}`} hidden={true} id={termLabel}>
+          {children}
+        </dd>
+      </div>
+    </>
   )
 }
 

--- a/src/components/Description/DescriptionAccordion.tsx
+++ b/src/components/Description/DescriptionAccordion.tsx
@@ -13,7 +13,7 @@ export const DescriptionAccordion = ({ term, children }: DescriptionAccordionPro
   return (
     <>
       <Helmet>
-        <script src="./src/components/Description/script.js" type="text/javascript" />
+        <script src="./src/components/Description/DescriptionAccordionScript.js" type="text/javascript" />
       </Helmet>
       <div className={`accordion ${styles.base} ${styles.accordion}`}>
         <dt className={`${styles.term} ${proseStyles.base}`}>

--- a/src/components/Description/DescriptionAccordion.tsx
+++ b/src/components/Description/DescriptionAccordion.tsx
@@ -1,15 +1,14 @@
 import { styles } from './Description.Styles'
 import { ChevronRightIcon } from '@heroicons/react/24/outline'
 import { proseStyles } from '../../utils/globalClasses'
-import {Helmet} from "react-helmet";
+import { Helmet } from 'react-helmet'
 export interface DescriptionAccordionProps {
   term: string
   children: React.ReactNode
 }
 
 export const DescriptionAccordion = ({ term, children }: DescriptionAccordionProps) => {
-
-  const termLabel = term && typeof term === 'string' ? 'accordion-' + term.toLowerCase().replace(/ +/g, '-') : '';
+  const termLabel = term && typeof term === 'string' ? 'accordion-' + term.toLowerCase().replace(/ +/g, '-') : ''
 
   return (
     <>
@@ -18,7 +17,7 @@ export const DescriptionAccordion = ({ term, children }: DescriptionAccordionPro
       </Helmet>
       <div className={`accordion ${styles.base} ${styles.accordion}`}>
         <dt className={`${styles.term} ${proseStyles.base}`}>
-          <button className={`accordion__button ${styles.button}`} aria-expanded='false' aria-controls={termLabel}>
+          <button className={`accordion__button ${styles.button}`} aria-expanded="false" aria-controls={termLabel}>
             {term}
             <ChevronRightIcon className={`accordion__icon ${styles.chevron} rotate-0}`} />
           </button>

--- a/src/components/Description/DescriptionAccordionScript.js
+++ b/src/components/Description/DescriptionAccordionScript.js
@@ -1,3 +1,4 @@
+/* eslint-env browser */
 var buttons = document.querySelectorAll('.accordion__button')
 
 if (buttons) {

--- a/src/components/Description/script.js
+++ b/src/components/Description/script.js
@@ -1,0 +1,27 @@
+var buttons = document.querySelectorAll('.accordion__button');
+
+if (buttons) {
+
+    buttons.forEach((button) => {
+
+        button.addEventListener('click', (event) => {
+            const target     = event.currentTarget,
+                icon         = target.querySelector('.accordion__icon'),
+                accordion    = target.closest('.accordion'),
+                content      = accordion.querySelector('.accordion__content'),
+                hidden       = content.hidden;
+
+            if( hidden ){
+                target.setAttribute('aria-expanded', 'true')
+                icon.classList.remove('rotate-0');
+                icon.classList.add('rotate-90');
+            } else {
+                target.setAttribute('aria-expanded', 'false')
+                icon.classList.add('rotate-0');
+                icon.classList.remove('rotate-90');
+            }
+
+            content.hidden = !hidden
+        })
+    })
+}

--- a/src/components/Description/script.js
+++ b/src/components/Description/script.js
@@ -1,27 +1,25 @@
-var buttons = document.querySelectorAll('.accordion__button');
+var buttons = document.querySelectorAll('.accordion__button')
 
 if (buttons) {
+  buttons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const target = event.currentTarget,
+        icon = target.querySelector('.accordion__icon'),
+        accordion = target.closest('.accordion'),
+        content = accordion.querySelector('.accordion__content'),
+        hidden = content.hidden
 
-    buttons.forEach((button) => {
+      if (hidden) {
+        target.setAttribute('aria-expanded', 'true')
+        icon.classList.remove('rotate-0')
+        icon.classList.add('rotate-90')
+      } else {
+        target.setAttribute('aria-expanded', 'false')
+        icon.classList.add('rotate-0')
+        icon.classList.remove('rotate-90')
+      }
 
-        button.addEventListener('click', (event) => {
-            const target     = event.currentTarget,
-                icon         = target.querySelector('.accordion__icon'),
-                accordion    = target.closest('.accordion'),
-                content      = accordion.querySelector('.accordion__content'),
-                hidden       = content.hidden;
-
-            if( hidden ){
-                target.setAttribute('aria-expanded', 'true')
-                icon.classList.remove('rotate-0');
-                icon.classList.add('rotate-90');
-            } else {
-                target.setAttribute('aria-expanded', 'false')
-                icon.classList.add('rotate-0');
-                icon.classList.remove('rotate-90');
-            }
-
-            content.hidden = !hidden
-        })
+      content.hidden = !hidden
     })
+  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3309,6 +3309,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-helmet@^6.1.9":
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.9.tgz#e79e0def2ad4047cb67e83c5be7cfb3d2121615a"
+  integrity sha512-nuOeTefP4yPTWHvjGksCBKb/4hsgJxSX7aSTjTIDFXJIkZ6Wo2Y4/cmE1FO9OlYBrHjKOer/0zLwY7s4qiQBtw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-places-autocomplete@7.2.12":
   version "7.2.12"
   resolved "https://registry.yarnpkg.com/@types/react-places-autocomplete/-/react-places-autocomplete-7.2.12.tgz#3f267730606167fd01b5586d3eeeb44ac88ff39c"
@@ -8539,10 +8546,20 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-fast-compare@^3.0.1:
+react-fast-compare@^3.0.1, react-fast-compare@^3.1.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
   integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-inspector@^6.0.0:
   version "6.0.2"
@@ -8627,6 +8644,11 @@ react-resize-detector@^7.1.2:
   integrity sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==
   dependencies:
     lodash "^4.17.21"
+
+react-side-effect@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
+  integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
 react-style-singleton@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
## PR Checklist & Notes

### What type of PR is this? (check all applicable)

- [ ] New component
- [ ] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Optimization / Build Tools
- [ ] Documentation Update

### Related Tickets & Documents

- Jira Ticket / Github Issue : [WSDEV-3808](https://itsjira.carleton.ca/browse/WSDEV-3808)

### Is this a breaking change?

If yes, please note which project will be impacted.

- [ ] Yes
- [x] No

### Have you made an entry in the Changelog?

If not, please make an entry or your PR will be declined. Add new entries under the "Unreleased" section of the changelog.

- [x] Yes
- [ ] No

### Have you made changes to dependencies?

If you've made changes to dependencies please note them here, adding if they've been added, removed or updated, including packages version where applicable.

- [x] Added
- [ ] Updated
- [ ] Removed
- [ ] Combo of any of the above
- [ ] No

Added Helmet package to add the scripts in head area.

### QA Instructions, Screenshots, Recordings

- Removed hooks in accordion component since its not compatible with Wordpress blocks.